### PR TITLE
changed title and dialogTitle for selection of theme in settings

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -92,4 +92,5 @@
     <string name="could_not_browse_artist">"Interpret %1$s konnte nicht gesucht werden  "</string>
     <string name="could_not_show_explore">Die Registerkarte \"Erkunden\" konnte nicht angezeigt werden</string>
     <string name="could_not_browse_playlist">"Playlist %1$s konnte nicht durchsucht werden  "</string>
+    <string name="theme">Design</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -100,4 +100,5 @@
     <string name="could_not_browse_artist">Impossible de trouver les albums de l\'artiste %1$s</string>
     <string name="could_not_show_explore">Impossible d\'afficher l\'onglet d\'exploration</string>
     <string name="could_not_browse_playlist">Impossible de trouver les titres de la playlist %1$s</string>
+    <string name="theme">Thème</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="player_not_ready">%1$s player was not ready</string>
     <string name="welcome_to_blade">Welcome to Blade player !</string>
     <string name="welcome_message">It seems like you did not configure any \'source\' of music (service from which Blade will get your music). Please go to settings (using the top right icon), \'Sources\', add a source using the + button, and click on it to configure it. When you\'re done, go back, hit the \'sync\' icon next to settings, and wait for synchronization. You\'re all set, listen to your music !</string>
+    <string name="theme">Theme</string>
     <string name="dark_theme">Dark theme</string>
     <string name="light_theme">Light theme</string>
     <string name="system_default">System default</string>

--- a/app/src/main/res/xml/header_preferences.xml
+++ b/app/src/main/res/xml/header_preferences.xml
@@ -10,11 +10,11 @@
     <ListPreference
         app:key="dark_theme"
         android:icon="@drawable/ic_dark_theme"
-        android:dialogTitle="@string/dark_theme"
+        android:dialogTitle="@string/theme"
         android:entries="@array/dark_theme_choice"
         android:entryValues="@array/dark_theme_choice_values"
         android:defaultValue="system_default"
-        android:title="@string/dark_theme" />
+        android:title="@string/theme" />
 
     <Preference
         app:fragment="v.blade.ui.SettingsActivity$AboutFragment"


### PR DESCRIPTION
The settings always show the menu item "Dark Theme", no matter which theme is actually selected. The same applies to the title in the theme selection dialog (see screenshot).

![settings_dialog](https://user-images.githubusercontent.com/49029181/151572283-7ee468c9-c890-443e-887b-47312dc4b1bc.png)

This PR replaces title and dialogTitle with a separate string resource.