### PR TITLE
[UI]: Add padding and app's logo in the `about` layout

### DIFF
--- a/app/src/main/res/layout/settings_fragment_about.xml
+++ b/app/src/main/res/layout/settings_fragment_about.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -9,12 +10,20 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
+        <ImageView
+            android:id="@+id/imageView2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            app:srcCompat="@mipmap/ic_launcher" />
+
         <com.google.android.material.textview.MaterialTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="20dp"
+            android:text="@string/app_name"
             android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Headline3"
-            android:text="@string/app_name" />
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Headline3" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/about_version_text"
@@ -25,9 +34,10 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/about_buildtype_text"
-            android:textAlignment="center"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="20dp"
+            android:textAlignment="center"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
 
         <com.google.android.material.textview.MaterialTextView
@@ -63,11 +73,15 @@
             android:layout_height="wrap_content"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
             android:layout_marginTop="20dp"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
             android:text="@string/about_libraries_used" />
 
         <com.google.android.material.textview.MaterialTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
             android:text="- Android Jetpack, license Apache 2.0, Copyright 2018 The Android Open Source Project, github.com/androidx/androidx"
             tools:ignore="HardcodedText" />
@@ -75,6 +89,8 @@
         <com.google.android.material.textview.MaterialTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
             android:text="- Picasso, license Apache 2.0, Copyright 2013 Square, Inc., github.com/square/picasso"
             tools:ignore="HardcodedText" />
@@ -82,6 +98,8 @@
         <com.google.android.material.textview.MaterialTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
             android:text="- Retrofit, license Apache 2.0, Copyright 2013 Square, Inc., github.com/square/retrofit"
             tools:ignore="HardcodedText" />
@@ -89,6 +107,8 @@
         <com.google.android.material.textview.MaterialTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
             android:text="- Spotify Android Auth, license Apache 2.0, Copyright 2015-2016 Spotify AB, github.com/spotify/android-auth"
             tools:ignore="HardcodedText" />
@@ -96,8 +116,11 @@
         <com.google.android.material.textview.MaterialTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            android:layout_marginBottom="20dp"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
             android:text="- librespot-java, license Apache 2.0, Copyright 2021 devgianlu, github.com/librespot-org/librespot-java"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
             tools:ignore="HardcodedText" />
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Hi! This PR is trying to achieve a more visually pleasing `about` layout. To let the chunks of text breathe, it adds padding and margins. It also adds the app's logo in there. Please bear with me as this is my first Android-oriented PR (not translation).

<details>
<summary>Image</summary>

![image](https://github.com/vhaudiquet/BladePlayer/assets/37738748/ee3ee0b6-778e-4fca-b804-c949bfa8c6d3)

</details>
